### PR TITLE
Edit grammar under how to use in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ported with love from the [Lorem Ipsum][git-repo:brackets-lorem-ipsum] brackets 
 
 > **Important**: For basic lorem ipsum text using the default settings just use the keybind `alt+l`.
 
-> **Important**: This README states that you need to use `_` to seperate the arguments however you can any characters you want by adding them to the config on the package settings page.
+> **Important**: This README states that you need to use `_` to separate the arguments however you can use any characters you want by adding them to the config on the package settings page.
 
 You can also add options to the lorem command with an underscore character followed by the option name. For example: `lorem_wrap40`. Multiple options can also be chained together. For example, typing `lorem_html_wrap40` and then pressing the `alt+l` will give you html formatted Lorem Ipsum text and a word wrap width of 40 characters. Using an unrecognized option will insert an error message into the document. Using more than one underscore character in a row (e.g. `lorem__html___p3`) will insert an error message into the document.
 


### PR DESCRIPTION
Changed 'seperate' to 'separate', and added the word 'use' where I thought appropriate. 
This is my first pull request so please let me know if I could do something better in the future! 
I like the lorem package by the way. Thanks!